### PR TITLE
Adding some kind of support to ICMS format and different delimiters

### DIFF
--- a/model/index.js
+++ b/model/index.js
@@ -1,5 +1,6 @@
 var request = require('request')
 var csv = require('csv')
+var detect = require('detect-csv')
 
 /**
  * model for interacting with a CKAN service API
@@ -113,6 +114,9 @@ function CkanModel (koop) {
               for (var i = 0; i < result.resources.length; i++) {
                 if (result.resources[i].format === 'CSV') {
                   item_url = host + self.ckan_dump_path + '/' + result.resources[i].id
+                }else if(result.resources[i].format == 'ICMS'){
+                    // It's working but not sure how to improve it
+                    item_url = result.resources[i].url+".csv";
                 }
               }
               if (item_url) {
@@ -123,8 +127,8 @@ function CkanModel (koop) {
                   if (notOk) {
                     return callback(new Error('Unable to retrieve data from ' + item_url + ' (' + data.statusCode + ')'))
                   }
-
-                  csv.parse(res, function (err, csv_data) {
+                  var guess = detect(res);
+                  csv.parse(res, {delimiter: guess.delimiter}, function (err, csv_data) {
                     if (err) return callback(err)
 
                     koop.GeoJSON.fromCSV(csv_data, function (err, geojson) {

--- a/model/index.js
+++ b/model/index.js
@@ -114,7 +114,7 @@ function CkanModel (koop) {
               for (var i = 0; i < result.resources.length; i++) {
                 if (result.resources[i].format === 'CSV') {
                   item_url = host + self.ckan_dump_path + '/' + result.resources[i].id
-                }else if( result.resources[i].format === 'ICMS' ) {
+                } else if (result.resources[i].format === 'ICMS') {
                   // It's working but not sure how to improve it
                   item_url = result.resources[i].url + '.csv'
                 }

--- a/model/index.js
+++ b/model/index.js
@@ -114,9 +114,9 @@ function CkanModel (koop) {
               for (var i = 0; i < result.resources.length; i++) {
                 if (result.resources[i].format === 'CSV') {
                   item_url = host + self.ckan_dump_path + '/' + result.resources[i].id
-                }else if(result.resources[i].format == 'ICMS'){
-                    // It's working but not sure how to improve it
-                    item_url = result.resources[i].url+".csv";
+                }else if( result.resources[i].format === 'ICMS' ) {
+                  // It's working but not sure how to improve it
+                  item_url = result.resources[i].url + '.csv'
                 }
               }
               if (item_url) {
@@ -127,7 +127,7 @@ function CkanModel (koop) {
                   if (notOk) {
                     return callback(new Error('Unable to retrieve data from ' + item_url + ' (' + data.statusCode + ')'))
                   }
-                  var guess = detect(res);
+                  var guess = detect(res)
                   csv.parse(res, {delimiter: guess.delimiter}, function (err, csv_data) {
                     if (err) return callback(err)
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "csv": "~0.4.0",
     "ejs": "~1.0.0",
     "request": "^2.51.0",
-    "sphericalmercator": "~1.0.2"
+    "sphericalmercator": "~1.0.2",
+    "detect-csv": "^1.1.0"
   },
   "devDependencies": {
     "koop": "^2.0.0",


### PR DESCRIPTION
I was trying to suscribe to this CKAN: [datos.santander.es](http://datos.santander.es/).

It seems to be managed by [RagTime](http://www.ragtime.de/start.html?lang_id=e) and that's why [the resources instead of CSV returns ICMS](http://datos.santander.es/catalogo/api/3/action/tag_show?id=gis) // [+info](http://www.xnoccio.com/es/opendata-all-in-one-icms-virtual-appliance/).

It's weird because when you use the standard API call [you see this](http://datos.santander.es/catalogo/api/3/action/package_show?id=plenos-municipales) where no CSV appears, but when you go inside the portal [you can find a CSV resource](http://datos.santander.es/resource/?ds=plenos-municipales&id=1d7b4a70-c77e-486e-9a3f-d4ce07042069&ft=CSV).

That's why I tried with this:
```javascript
if (result.resources[i].format === 'CSV') {
  item_url = host + self.ckan_dump_path + '/' + result.resources[i].id
}else if(result.resources[i].format == 'ICMS'){
    // It's working but not sure how to improve it
    item_url = result.resources[i].url+".csv";
}
```
And it worked, but maybe I should find a better way to do this hehe.

At the same time I notice that no others delimiters are supported (just ',') and in Spain we usually use ';' instead; so I decided to give a try to [detect-csv module](https://github.com/finnp/detect-csv) and ... it did the work perfectly!, so I decided to include it.

I hope this can help somehow.

Best regards,
Raul